### PR TITLE
Add admin and volunteer guides

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -1,0 +1,44 @@
+# Admin Guide
+
+This document explains how to manage the app as an administrator.
+
+## Getting Started
+
+- **Sign In** with your admin credentials.
+- The bottom navigation bar will show additional links only admins can see, such as **Admin Events** and **Volunteers**.
+
+## Managing Events
+
+1. **Create Events**
+   - Navigate to **Admin Events** and tap **Create Event**.
+   - Fill out the event details: title, description, date, and any shifts.
+   - Save the event to store it in Firestore and schedule reminders for volunteers.
+
+2. **Edit or Duplicate Events**
+   - From the Admin Events list, choose an event and tap **Edit** to modify details.
+   - You can also duplicate an event to quickly create a similar one.
+
+3. **Archive Events**
+   - After an event is complete, you may archive it. This keeps the event history but removes it from the active list.
+
+4. **Manage Shifts and Volunteers**
+   - Within an individual event, you can see the list of shifts and which volunteers have signed up.
+   - Tap a volunteer name to view their profile or remove them from a shift if needed.
+
+## Sending Notifications
+
+- Admins can send push notifications to all volunteers or to those registered for specific events.
+- Use the **Send Message** option inside an event to broadcast important updates.
+
+## Viewing Volunteers
+
+- The **Volunteers** screen lists every registered user along with their contact information and interests.
+- Export volunteer data as CSV if you need a roster for offline use.
+
+## Tips and Best Practices
+
+- Keep event details and shift times accurate so volunteers can plan accordingly.
+- Regularly archive completed events to keep the app organized.
+- Check the Notifications screen to verify messages have been delivered.
+
+Happy organizing!

--- a/docs/admin-guide.pdf
+++ b/docs/admin-guide.pdf
@@ -1,0 +1,78 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 2785 >>
+stream
+BT
+/F1 12 Tf
+1 0 0 1 50 800 Tm (# Admin Guide) Tj
+1 0 0 1 50 786 Tm () Tj
+1 0 0 1 50 772 Tm (This document explains how to manage the app as an administrator.) Tj
+1 0 0 1 50 758 Tm () Tj
+1 0 0 1 50 744 Tm (## Getting Started) Tj
+1 0 0 1 50 730 Tm () Tj
+1 0 0 1 50 716 Tm (- **Sign In** with your admin credentials.) Tj
+1 0 0 1 50 702 Tm (- The bottom navigation bar will show additional links only admins can see, such as **Admin Events** and **Volunteers**.) Tj
+1 0 0 1 50 688 Tm () Tj
+1 0 0 1 50 674 Tm (## Managing Events) Tj
+1 0 0 1 50 660 Tm () Tj
+1 0 0 1 50 646 Tm (1. **Create Events**) Tj
+1 0 0 1 50 632 Tm (   - Navigate to **Admin Events** and tap **Create Event**.) Tj
+1 0 0 1 50 618 Tm (   - Fill out the event details: title, description, date, and any shifts.) Tj
+1 0 0 1 50 604 Tm (   - Save the event to store it in Firestore and schedule reminders for volunteers.) Tj
+1 0 0 1 50 590 Tm () Tj
+1 0 0 1 50 576 Tm (2. **Edit or Duplicate Events**) Tj
+1 0 0 1 50 562 Tm (   - From the Admin Events list, choose an event and tap **Edit** to modify details.) Tj
+1 0 0 1 50 548 Tm (   - You can also duplicate an event to quickly create a similar one.) Tj
+1 0 0 1 50 534 Tm () Tj
+1 0 0 1 50 520 Tm (3. **Archive Events**) Tj
+1 0 0 1 50 506 Tm (   - After an event is complete, you may archive it. This keeps the event history but removes it from the active list.) Tj
+1 0 0 1 50 492 Tm () Tj
+1 0 0 1 50 478 Tm (4. **Manage Shifts and Volunteers**) Tj
+1 0 0 1 50 464 Tm (   - Within an individual event, you can see the list of shifts and which volunteers have signed up.) Tj
+1 0 0 1 50 450 Tm (   - Tap a volunteer name to view their profile or remove them from a shift if needed.) Tj
+1 0 0 1 50 436 Tm () Tj
+1 0 0 1 50 422 Tm (## Sending Notifications) Tj
+1 0 0 1 50 408 Tm () Tj
+1 0 0 1 50 394 Tm (- Admins can send push notifications to all volunteers or to those registered for specific events.) Tj
+1 0 0 1 50 380 Tm (- Use the **Send Message** option inside an event to broadcast important updates.) Tj
+1 0 0 1 50 366 Tm () Tj
+1 0 0 1 50 352 Tm (## Viewing Volunteers) Tj
+1 0 0 1 50 338 Tm () Tj
+1 0 0 1 50 324 Tm (- The **Volunteers** screen lists every registered user along with their contact information and interests.) Tj
+1 0 0 1 50 310 Tm (- Export volunteer data as CSV if you need a roster for offline use.) Tj
+1 0 0 1 50 296 Tm () Tj
+1 0 0 1 50 282 Tm (## Tips and Best Practices) Tj
+1 0 0 1 50 268 Tm () Tj
+1 0 0 1 50 254 Tm (- Keep event details and shift times accurate so volunteers can plan accordingly.) Tj
+1 0 0 1 50 240 Tm (- Regularly archive completed events to keep the app organized.) Tj
+1 0 0 1 50 226 Tm (- Check the Notifications screen to verify messages have been delivered.) Tj
+1 0 0 1 50 212 Tm () Tj
+1 0 0 1 50 198 Tm (Happy organizing!) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000003078 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+3148
+%%EOF

--- a/docs/newcomer-guide.md
+++ b/docs/newcomer-guide.md
@@ -1,0 +1,52 @@
+# Newcomer Guide
+
+Welcome to the project! This short guide introduces the overall structure of the codebase and highlights key concepts to help you get started quickly.
+
+## General Structure
+
+- **App Entry & Navigation**
+  - `App.js` sets up the React Navigation stack with screens like `Login`, `Signup`, `Events`, `AdminEvents`, and `Profile`. It also handles push-notification setup when the app loads.
+
+- **Firebase Configuration**
+  - `firebaseConfig.js` initializes Firebase services (Firestore, Authentication, and Storage) and exports them for other modules to use.
+
+- **Push Notifications**
+  - `expoPushNotifications.js` registers the device for Expo push notifications. It requests permissions and creates an Android channel if necessary.
+
+- **API Helpers (in `pages/api/` directory)**
+  - `event.js` manages creating/editing events, scheduling reminders, and sending push notifications.
+  - `users.js` includes authentication helpers and utilities to load the current user or store the device's notification token.
+
+- **UI Components**
+  - `components/NavBar.js` renders the bottom navigation bar. It checks whether the user is an admin to show extra links such as "Volunteers".
+
+- **Screens (in `pages/` directory)**
+  - `events.js` lists upcoming events with filters and navigation to individual event pages.
+  - `signup.js` collects user details and interests before creating a user in Firebase Auth.
+  - `waiver.js` stores emergency contact information in Firestore when the user accepts the waiver.
+  - `profile.js` allows users to edit personal info, manage interests, and drop from events.
+  - `notifications.js` displays push notifications retrieved from Firestore.
+  - Admin-only screens live under `pages/admin/` for creating, editing, and viewing events, managing volunteers, and reviewing archived events.
+
+## Important Concepts
+
+1. **Firebase Integration**
+   - Firestore, Auth, and Storage are initialized in `firebaseConfig.js`. Many modules import these directly.
+2. **Push Notifications**
+   - The device's Expo notification token is registered on startup and stored in the user's document. Event reminders are scheduled in `pages/api/event.js`.
+3. **Admin vs. Regular Users**
+   - Screens check if the logged-in user is an admin to show different navigation options and event management features.
+4. **Events & Shifts**
+   - Events store shift IDs referencing separate `shifts` documents. Users sign up for shifts, and reminders are scheduled accordingly.
+5. **Data Flow**
+   - Screens fetch data from Firestore on mount or when focused. Updates are written back to Firestore directly from the UI.
+
+## Next Steps to Explore
+
+- Review the Firestore schema for events, shifts, users, waivers, and notifications.
+- Explore the admin-specific pages under `pages/admin/` to understand event creation and volunteer management.
+- Examine `expoPushNotifications.js` and `pages/api/event.js` to see how notifications are registered and scheduled.
+- Study `Login.js`, `Signup.js`, and `Waiver.js` to follow the user onboarding flow.
+- Consider how error cases are handled throughout the screens and API helper functions.
+
+We hope this overview helps you get comfortable with the project. Happy coding!

--- a/docs/newcomer-guide.pdf
+++ b/docs/newcomer-guide.pdf
@@ -1,0 +1,86 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 4438 >>
+stream
+BT
+/F1 12 Tf
+1 0 0 1 50 800 Tm (# Newcomer Guide) Tj
+1 0 0 1 50 786 Tm () Tj
+1 0 0 1 50 772 Tm (Welcome to the project! This short guide introduces the overall structure of the codebase and highlights key concepts to help you get started quickly.) Tj
+1 0 0 1 50 758 Tm () Tj
+1 0 0 1 50 744 Tm (## General Structure) Tj
+1 0 0 1 50 730 Tm () Tj
+1 0 0 1 50 716 Tm (- **App Entry & Navigation**) Tj
+1 0 0 1 50 702 Tm (  - `App.js` sets up the React Navigation stack with screens like `Login`, `Signup`, `Events`, `AdminEvents`, and `Profile`. It also handles push-notification setup when the app loads.) Tj
+1 0 0 1 50 688 Tm () Tj
+1 0 0 1 50 674 Tm (- **Firebase Configuration**) Tj
+1 0 0 1 50 660 Tm (  - `firebaseConfig.js` initializes Firebase services \(Firestore, Authentication, and Storage\) and exports them for other modules to use.) Tj
+1 0 0 1 50 646 Tm () Tj
+1 0 0 1 50 632 Tm (- **Push Notifications**) Tj
+1 0 0 1 50 618 Tm (  - `expoPushNotifications.js` registers the device for Expo push notifications. It requests permissions and creates an Android channel if necessary.) Tj
+1 0 0 1 50 604 Tm () Tj
+1 0 0 1 50 590 Tm (- **API Helpers \(in `pages/api/` directory\)**) Tj
+1 0 0 1 50 576 Tm (  - `event.js` manages creating/editing events, scheduling reminders, and sending push notifications.) Tj
+1 0 0 1 50 562 Tm (  - `users.js` includes authentication helpers and utilities to load the current user or store the device's notification token.) Tj
+1 0 0 1 50 548 Tm () Tj
+1 0 0 1 50 534 Tm (- **UI Components**) Tj
+1 0 0 1 50 520 Tm (  - `components/NavBar.js` renders the bottom navigation bar. It checks whether the user is an admin to show extra links such as "Volunteers".) Tj
+1 0 0 1 50 506 Tm () Tj
+1 0 0 1 50 492 Tm (- **Screens \(in `pages/` directory\)**) Tj
+1 0 0 1 50 478 Tm (  - `events.js` lists upcoming events with filters and navigation to individual event pages.) Tj
+1 0 0 1 50 464 Tm (  - `signup.js` collects user details and interests before creating a user in Firebase Auth.) Tj
+1 0 0 1 50 450 Tm (  - `waiver.js` stores emergency contact information in Firestore when the user accepts the waiver.) Tj
+1 0 0 1 50 436 Tm (  - `profile.js` allows users to edit personal info, manage interests, and drop from events.) Tj
+1 0 0 1 50 422 Tm (  - `notifications.js` displays push notifications retrieved from Firestore.) Tj
+1 0 0 1 50 408 Tm (  - Admin-only screens live under `pages/admin/` for creating, editing, and viewing events, managing volunteers, and reviewing archived events.) Tj
+1 0 0 1 50 394 Tm () Tj
+1 0 0 1 50 380 Tm (## Important Concepts) Tj
+1 0 0 1 50 366 Tm () Tj
+1 0 0 1 50 352 Tm (1. **Firebase Integration**) Tj
+1 0 0 1 50 338 Tm (   - Firestore, Auth, and Storage are initialized in `firebaseConfig.js`. Many modules import these directly.) Tj
+1 0 0 1 50 324 Tm (2. **Push Notifications**) Tj
+1 0 0 1 50 310 Tm (   - The device's Expo notification token is registered on startup and stored in the user's document. Event reminders are scheduled in `pages/api/event.js`.) Tj
+1 0 0 1 50 296 Tm (3. **Admin vs. Regular Users**) Tj
+1 0 0 1 50 282 Tm (   - Screens check if the logged-in user is an admin to show different navigation options and event management features.) Tj
+1 0 0 1 50 268 Tm (4. **Events & Shifts**) Tj
+1 0 0 1 50 254 Tm (   - Events store shift IDs referencing separate `shifts` documents. Users sign up for shifts, and reminders are scheduled accordingly.) Tj
+1 0 0 1 50 240 Tm (5. **Data Flow**) Tj
+1 0 0 1 50 226 Tm (   - Screens fetch data from Firestore on mount or when focused. Updates are written back to Firestore directly from the UI.) Tj
+1 0 0 1 50 212 Tm () Tj
+1 0 0 1 50 198 Tm (## Next Steps to Explore) Tj
+1 0 0 1 50 184 Tm () Tj
+1 0 0 1 50 170 Tm (- Review the Firestore schema for events, shifts, users, waivers, and notifications.) Tj
+1 0 0 1 50 156 Tm (- Explore the admin-specific pages under `pages/admin/` to understand event creation and volunteer management.) Tj
+1 0 0 1 50 142 Tm (- Examine `expoPushNotifications.js` and `pages/api/event.js` to see how notifications are registered and scheduled.) Tj
+1 0 0 1 50 128 Tm (- Study `Login.js`, `Signup.js`, and `Waiver.js` to follow the user onboarding flow.) Tj
+1 0 0 1 50 114 Tm (- Consider how error cases are handled throughout the screens and API helper functions.) Tj
+1 0 0 1 50 100 Tm () Tj
+1 0 0 1 50 86 Tm (We hope this overview helps you get comfortable with the project. Happy coding!) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000004731 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+4801
+%%EOF

--- a/docs/volunteer-guide.md
+++ b/docs/volunteer-guide.md
@@ -1,0 +1,39 @@
+# Volunteer Guide
+
+This guide walks you through the app features available to regular volunteers.
+
+## Getting Started
+
+- **Sign Up** using the in-app registration form if you don't have an account.
+- After signing in, you will see available events on the **Events** screen.
+
+## Joining Events and Shifts
+
+1. **Browse Events**
+   - Open the **Events** tab to see upcoming opportunities.
+   - Tap an event to view its description and available shifts.
+
+2. **Sign Up for a Shift**
+   - Choose a shift that fits your schedule and tap **Join**.
+   - The app will schedule a reminder notification so you don't forget.
+
+3. **Leave a Shift**
+   - If your plans change, open the event and tap **Leave** next to your shift.
+   - This cancels the reminder notification for that shift.
+
+## Profile and Preferences
+
+- Visit the **Profile** screen to update your contact information, interests, and emergency contacts.
+- You can also review events you've joined and drop them if necessary.
+
+## Notifications
+
+- The **Notifications** tab lists reminders and announcements sent by admins.
+- Make sure push notifications are enabled on your device so you don't miss updates.
+
+## Getting Help
+
+- If you encounter issues, reach out to an admin via the contact information in the event details.
+- The app also includes a simple FAQ in the **Profile** screen to address common questions.
+
+Thank you for volunteering!

--- a/docs/volunteer-guide.pdf
+++ b/docs/volunteer-guide.pdf
@@ -1,0 +1,73 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 2308 >>
+stream
+BT
+/F1 12 Tf
+1 0 0 1 50 800 Tm (# Volunteer Guide) Tj
+1 0 0 1 50 786 Tm () Tj
+1 0 0 1 50 772 Tm (This guide walks you through the app features available to regular volunteers.) Tj
+1 0 0 1 50 758 Tm () Tj
+1 0 0 1 50 744 Tm (## Getting Started) Tj
+1 0 0 1 50 730 Tm () Tj
+1 0 0 1 50 716 Tm (- **Sign Up** using the in-app registration form if you don't have an account.) Tj
+1 0 0 1 50 702 Tm (- After signing in, you will see available events on the **Events** screen.) Tj
+1 0 0 1 50 688 Tm () Tj
+1 0 0 1 50 674 Tm (## Joining Events and Shifts) Tj
+1 0 0 1 50 660 Tm () Tj
+1 0 0 1 50 646 Tm (1. **Browse Events**) Tj
+1 0 0 1 50 632 Tm (   - Open the **Events** tab to see upcoming opportunities.) Tj
+1 0 0 1 50 618 Tm (   - Tap an event to view its description and available shifts.) Tj
+1 0 0 1 50 604 Tm () Tj
+1 0 0 1 50 590 Tm (2. **Sign Up for a Shift**) Tj
+1 0 0 1 50 576 Tm (   - Choose a shift that fits your schedule and tap **Join**.) Tj
+1 0 0 1 50 562 Tm (   - The app will schedule a reminder notification so you don't forget.) Tj
+1 0 0 1 50 548 Tm () Tj
+1 0 0 1 50 534 Tm (3. **Leave a Shift**) Tj
+1 0 0 1 50 520 Tm (   - If your plans change, open the event and tap **Leave** next to your shift.) Tj
+1 0 0 1 50 506 Tm (   - This cancels the reminder notification for that shift.) Tj
+1 0 0 1 50 492 Tm () Tj
+1 0 0 1 50 478 Tm (## Profile and Preferences) Tj
+1 0 0 1 50 464 Tm () Tj
+1 0 0 1 50 450 Tm (- Visit the **Profile** screen to update your contact information, interests, and emergency contacts.) Tj
+1 0 0 1 50 436 Tm (- You can also review events you've joined and drop them if necessary.) Tj
+1 0 0 1 50 422 Tm () Tj
+1 0 0 1 50 408 Tm (## Notifications) Tj
+1 0 0 1 50 394 Tm () Tj
+1 0 0 1 50 380 Tm (- The **Notifications** tab lists reminders and announcements sent by admins.) Tj
+1 0 0 1 50 366 Tm (- Make sure push notifications are enabled on your device so you don't miss updates.) Tj
+1 0 0 1 50 352 Tm () Tj
+1 0 0 1 50 338 Tm (## Getting Help) Tj
+1 0 0 1 50 324 Tm () Tj
+1 0 0 1 50 310 Tm (- If you encounter issues, reach out to an admin via the contact information in the event details.) Tj
+1 0 0 1 50 296 Tm (- The app also includes a simple FAQ in the **Profile** screen to address common questions.) Tj
+1 0 0 1 50 282 Tm () Tj
+1 0 0 1 50 268 Tm (Thank you for volunteering!) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000002601 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+2671
+%%EOF

--- a/scripts/markdown_to_pdf.py
+++ b/scripts/markdown_to_pdf.py
@@ -1,0 +1,40 @@
+import sys, os
+
+def text_to_pdf(text, out_file):
+    lines = text.splitlines()
+    y = 800  # starting y position
+    pdf_lines = ["BT", "/F1 12 Tf"]
+    for line in lines:
+        safe = line.replace('(', '\\(').replace(')', '\\)')
+        pdf_lines.append(f"1 0 0 1 50 {y} Tm ({safe}) Tj")
+        y -= 14
+    pdf_lines.append("ET")
+    stream_data = "\n".join(pdf_lines)
+    obj4 = f"4 0 obj\n<< /Length {len(stream_data)} >>\nstream\n{stream_data}\nendstream\nendobj\n"
+    objects = []
+    objects.append("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+    objects.append("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+    objects.append("3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n")
+    objects.append(obj4)
+    objects.append("5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n")
+    offsets = []
+    pdf = "%PDF-1.4\n"
+    for obj in objects:
+        offsets.append(len(pdf))
+        pdf += obj
+    xref_pos = len(pdf)
+    pdf += f"xref\n0 {len(objects)+1}\n"
+    pdf += "0000000000 65535 f \n"
+    for off in offsets:
+        pdf += f"{off:010d} 00000 n \n"
+    pdf += f"trailer\n<< /Root 1 0 R /Size {len(objects)+1} >>\nstartxref\n{xref_pos}\n%%EOF"
+    with open(out_file, 'wb') as f:
+        f.write(pdf.encode('latin1'))
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print('Usage: markdown_to_pdf.py <input.md> <output.pdf>')
+        sys.exit(1)
+    with open(sys.argv[1], 'r') as f:
+        text = f.read()
+    text_to_pdf(text, sys.argv[2])


### PR DESCRIPTION
## Summary
- add admin guide with app management instructions
- add volunteer guide explaining how to sign up for events
- generate PDF versions of both guides

## Testing
- `npm test` *(fails: Missing script)*
- `python scripts/markdown_to_pdf.py docs/admin-guide.md docs/admin-guide.pdf`
- `python scripts/markdown_to_pdf.py docs/volunteer-guide.md docs/volunteer-guide.pdf`
- `python scripts/markdown_to_pdf.py docs/newcomer-guide.md docs/newcomer-guide.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68618b39daec8324ac3d57b4989519ff